### PR TITLE
fix: utils/fetch.js가 에러를 반환하도록 수정했다

### DIFF
--- a/src/utils/fetch.js
+++ b/src/utils/fetch.js
@@ -8,6 +8,7 @@ export const fetch = async (url, options) => {
     return result.data;
   } catch (error) {
     console.error(error);
+    return error;
   }
 };
 
@@ -22,5 +23,6 @@ export const authFetch = async (url, options) => {
     return result.data;
   } catch (error) {
     console.error(error);
+    return error;
   }
 };


### PR DESCRIPTION
# 수정사항

요청 실패 시 추가 동작을 위해서 `utils/fetch.js`의 요청 함수들에 error를 반환하도록 수정했습니다

# 참고 캡처본

## 캡처에 사용한 코드
```
import React, { useEffect } from 'react';
import { fetch } from '@utils/fetch';

const test = async () => {
  const response = await fetch('/login', {
    method: 'POST',
    data: {
      email: 'feel@naver.com',
      password: 'test',
    },
  });
  console.log(response);
};

function LoginPage() {
  useEffect(() => {
    test();
  }, []);

  return <div>LoginPage</div>;
}

export default LoginPage;
```
페이지 마운트 이후 요청을 보내도록 했습니다

## 캡처본

![fetch 기존 요청 실패](https://user-images.githubusercontent.com/50919342/173301617-38a3a0f9-6d2f-4b92-8a0b-85131ccc8d9c.png)

기존 요청은 실패 시 아무것도 반환하지 않아서 undefined입니다

![fetch 수정 요청 실패](https://user-images.githubusercontent.com/50919342/173302017-a1ead84b-987a-44ad-a9ad-ceeb15644035.png)

수정된 요청은 실패 시 error를 반환합니다
이에 대해 status 등 추가적으로 판별 후 로직 설정이 가능합니다

![fetch 요청 정상](https://user-images.githubusercontent.com/50919342/173302190-a55134d0-6ad6-4eac-a80a-af039e7b4246.png)

요청 성공시에는 기존과 동일합니다