### PR TITLE
fix: 라우터를 수정했다. `prop-types` import 방식을 통일했다.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,8 @@ import PostEditPage from '@pages/PostEditPage';
 import PostWritePage from '@pages/PostWritePage';
 import ProfilePage from '@pages/ProfilePage';
 import SearchPage from '@pages/SearchPage';
+import SearchPostPage from '@pages/SearchPostPage';
+import SearchUserPage from '@pages/SearchUserPage';
 import SignupPage from '@pages/SignupPage';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 
@@ -18,14 +20,16 @@ function App() {
       <Routes>
         <Route path="/" element={<Navbar />}>
           <Route index element={<HomePage />} />
-          <Route path="/:user/alram" element={<AlramPage />} />
-          <Route path="/search/all" element={<SearchPage />} />
-          <Route path="/channel/:channelId" element={<ChannelPage />} />
-          <Route path="/categories" element={<CategoriesPage />} />
-          <Route path="/posts" element={<PostWritePage />} />
-          <Route path="/:postId/edit" element={<PostEditPage />} />
-          <Route path="/:postId/details" element={<PostDetailPage />} />
+          <Route path="alram/:user" element={<AlramPage />} />
+          <Route path="search/all" element={<SearchPage />} />
+          <Route path="search/user" element={<SearchUserPage />} />
+          <Route path="search/post" element={<SearchPostPage />} />
+          <Route path="channel/:channelId" element={<ChannelPage />} />
+          <Route path="channel/categories" element={<CategoriesPage />} />
+          <Route path="posts/write" element={<PostWritePage />} />
+          <Route path="posts/edit/:postId" element={<PostEditPage />} />
         </Route>
+        <Route path="posts/details/:postId" element={<PostDetailPage />} />
         <Route path="login" element={<LoginPage />} />
         <Route path="signup" element={<SignupPage />} />
         <Route path="profile" element={<ProfilePage />} />

--- a/src/components/Avatar/AvatarGroup.js
+++ b/src/components/Avatar/AvatarGroup.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 
 function AvatarGroup({ children, shape, size, ...props }) {
   const avatars = React.Children.toArray(children)
@@ -29,10 +29,10 @@ function AvatarGroup({ children, shape, size, ...props }) {
 }
 
 AvatarGroup.propTypes = {
-  children: propTypes.node.isRequired,
-  shape: propTypes.oneOf(['circle', 'round', 'square']),
-  size: propTypes.oneOfType([propTypes.number, propTypes.string]),
-  props: propTypes.object,
+  children: PropTypes.node.isRequired,
+  shape: PropTypes.oneOf(['circle', 'round', 'square']),
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  props: PropTypes.object,
 };
 
 AvatarGroup.defaultProps = {

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import React, { useEffect, useState } from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import ImageComponent from '@components/Image';
 import AvatarGroup from './AvatarGroup';
 
@@ -71,15 +71,15 @@ Avatar.defaultProps = {
 };
 
 Avatar.propTypes = {
-  lazy: propTypes.bool,
-  threshold: propTypes.number,
-  src: propTypes.string,
-  size: propTypes.oneOfType([propTypes.number, propTypes.string]),
-  shape: propTypes.oneOf(['circle', 'round', 'square']),
-  placeholder: propTypes.string,
-  alt: propTypes.string,
-  mode: propTypes.oneOf(['contain', 'cover', 'fill']),
-  __TYPE: propTypes.oneOf(['Avatar']),
+  lazy: PropTypes.bool,
+  threshold: PropTypes.number,
+  src: PropTypes.string,
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  shape: PropTypes.oneOf(['circle', 'round', 'square']),
+  placeholder: PropTypes.string,
+  alt: PropTypes.string,
+  mode: PropTypes.oneOf(['contain', 'cover', 'fill']),
+  __TYPE: PropTypes.oneOf(['Avatar']),
 };
 
 Avatar.Group = AvatarGroup;

--- a/src/components/Badge/index.js
+++ b/src/components/Badge/index.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
 const BadgeContainer = styled.div`

--- a/src/components/Divider/index.js
+++ b/src/components/Divider/index.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
 const Line = styled.hr`

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 
 function Header({ children, level = 1, strong, underline, color, ...props }) {
   let Tag = `h${level}`;

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import propTypes from 'prop-types';
+import PropTypes from 'prop-types';
 
 // 컴포넌트가 생성될 때 재생성을 방지하기 위해서 전역적으로 생성
 let observer = null;
@@ -69,27 +69,27 @@ function Image({
 }
 
 Image.propTypes = {
-  src: propTypes.string.isRequired,
-  alt: propTypes.string,
-  width: propTypes.oneOfType([propTypes.number, propTypes.string]),
-  height: propTypes.oneOfType([propTypes.number, propTypes.string]),
-  mode: propTypes.oneOf(['contain', 'cover', 'fill']),
-  block: propTypes.bool,
-  lazy: propTypes.bool,
-  threshold: propTypes.number,
-  placeholder: propTypes.string,
-  style: propTypes.object,
+  src: PropTypes.string.isRequired,
+  alt: PropTypes.string,
+  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  mode: PropTypes.oneOf(['contain', 'cover', 'fill']),
+  block: PropTypes.bool,
+  lazy: PropTypes.bool,
+  threshold: PropTypes.number,
+  placeholder: PropTypes.string,
+  style: PropTypes.object,
 };
 
 Image.defaultProps = {
   alt: '',
   width: 100,
   height: 80,
-  mode: propTypes.string,
-  block: propTypes.bool,
-  lazy: propTypes.bool,
+  mode: PropTypes.string,
+  block: PropTypes.bool,
+  lazy: PropTypes.bool,
   threshold: 0,
-  placeholder: propTypes.string,
+  placeholder: PropTypes.string,
   style: {},
 };
 

--- a/src/components/Topbar/Sidebar.js
+++ b/src/components/Topbar/Sidebar.js
@@ -1,4 +1,4 @@
-import { PropTypes } from 'prop-types';
+import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import Drawer from '@mui/material/Drawer';
 import IconButton from '@mui/material/IconButton';

--- a/src/pages/SearchPostPage.js
+++ b/src/pages/SearchPostPage.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function SearchPostPage() {
+  return <div>SearchPostPage</div>;
+}
+
+export default SearchPostPage;

--- a/src/pages/SearchUserPage.js
+++ b/src/pages/SearchUserPage.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function SearchUserPage() {
+  return <div>SearchUserPage</div>;
+}
+
+export default SearchUserPage;


### PR DESCRIPTION
## 수정 사항
### 임시로 작성되었던 라우팅 관련 코드를 현재 프로젝트에 맞추어 수정.
- 검색 페이지를 위해서 `SearchPostPage`와 `SearchUserPage`를 추가하고 관련 라우팅 코드를 추가.
- url param이 url 가장 끝에 위치하도록 수정.
- 여러 도메인을 연관성이 있는 도메인으로 통합. (`channel`, `posts`, `search` 등)

### `prop-types`를 import 하는 방식을 통일.
✅
```js
import PropTypes from 'prop-types'
```
❌
```js
import propTypes from 'prop-types'
import { propTypes } from 'prop-types'
```