### PR TITLE
feat: login modal을 추가했다, context user 데이터를 추가했다

### DIFF
--- a/src/components/LoginModal/index.js
+++ b/src/components/LoginModal/index.js
@@ -1,0 +1,81 @@
+import styled from '@emotion/styled';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import Modal from '@mui/material/Modal';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+import { COLOR_MAIN } from '@utils/color';
+
+const ModalContentWrapper = styled(Box)`
+  position: absolute;
+  top: 50%;
+  left: 2rem;
+  right: 2rem;
+  transform: translate(0, -50%);
+  background-color: white;
+  border: 2px solid ${COLOR_MAIN};
+  box-shadow: 24;
+  padding: 2rem;
+`;
+
+const P = styled.p`
+  margin-bottom: 1rem;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+`;
+
+const NoneDecorationLink = styled(Link)`
+  text-decoration: none;
+`;
+
+const ColorButton = styled(Button)`
+  color: black;
+  border-color: ${COLOR_MAIN};
+
+  &:hover {
+    border-color: ${COLOR_MAIN};
+  }
+`;
+
+function LoginModal({ visible, handleCloseModal }) {
+  return (
+    <Modal
+      open={visible}
+      onClose={handleCloseModal}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <ModalContentWrapper>
+        <P>로그인된 사용자만 이용 가능합니다</P>
+        <P>지금 로그인 하시겠습니까?</P>
+        <ButtonContainer>
+          <ColorButton variant="outlined" size="small">
+            <NoneDecorationLink to="/login">로그인</NoneDecorationLink>
+          </ColorButton>
+          <ColorButton
+            variant="outlined"
+            size="small"
+            onClick={handleCloseModal}
+          >
+            닫기
+          </ColorButton>
+        </ButtonContainer>
+      </ModalContentWrapper>
+    </Modal>
+  );
+}
+
+LoginModal.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  handleCloseModal: PropTypes.func,
+};
+
+LoginModal.defaultProps = {
+  handleCloseModal: () => {},
+};
+
+export default LoginModal;

--- a/src/contexts/ContextProvider.js
+++ b/src/contexts/ContextProvider.js
@@ -7,12 +7,19 @@ export const actionContext = createContext();
 function ContextProvider({ children }) {
   const [state, setState] = useState({
     test: 100,
+    user: null,
   });
 
   const actions = useMemo(
     () => ({
       changeTest(newValue) {
         setState((prevState) => ({ ...prevState, test: newValue }));
+      },
+      login(user) {
+        setState((prevState) => ({
+          ...prevState,
+          user,
+        }));
       },
     }),
     []

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -11,6 +11,7 @@ import { COLOR_BG, COLOR_MAIN } from '@utils/color';
 import useForm from '@hooks/useForm';
 import { fetch } from '@utils/fetch';
 import useCookieToken from '@hooks/useCookieToken';
+import useActionContext from '@hooks/useActionContext';
 
 const ContentWrapper = styled.div`
   padding: 1.5rem;
@@ -89,6 +90,7 @@ function LoginPage() {
 
   const navigate = useNavigate();
   const { isLogin, setCookie } = useCookieToken();
+  const { login } = useActionContext();
   const { values, errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: {
       id: '',
@@ -120,6 +122,7 @@ function LoginPage() {
       }
 
       setCookie(response.token);
+      login(response.user);
       navigate('/');
     },
     validate: ({ id, password }) => {

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -4,7 +4,9 @@ import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
 import Alert from '@mui/material/Alert';
-import { useNavigate } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import { useNavigate, Link } from 'react-router-dom';
 import { COLOR_BG, COLOR_MAIN } from '@utils/color';
 import useForm from '@hooks/useForm';
 import { fetch } from '@utils/fetch';
@@ -61,6 +63,17 @@ const LoginButton = styled(Button)`
 
 const LoginWarningAlert = styled(Alert)`
   font-size: 0.75rem;
+`;
+
+const SignupLinkBox = styled(Box)`
+  margin-top: 1rem;
+  text-align: center;
+`;
+
+const SignupLink = styled(Link)`
+  color: red;
+  font-weight: bold;
+  text-decoration: none;
 `;
 
 const helperText = {
@@ -172,6 +185,10 @@ function LoginPage() {
           </LoginButtonWrapper>
         </Form>
       </FormWrapper>
+      <SignupLinkBox>
+        아이디 없으신가요?&nbsp;
+        <SignupLink to="/signup">회원가입하기</SignupLink>
+      </SignupLinkBox>
     </ContentWrapper>
   );
 }

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -5,7 +5,6 @@ import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
 import Alert from '@mui/material/Alert';
 import Box from '@mui/material/Box';
-import Typography from '@mui/material/Typography';
 import { useNavigate, Link } from 'react-router-dom';
 import { COLOR_BG, COLOR_MAIN } from '@utils/color';
 import useForm from '@hooks/useForm';
@@ -123,7 +122,6 @@ function LoginPage() {
 
       setCookie(response.token);
       login(response.user);
-      navigate('/');
     },
     validate: ({ id, password }) => {
       const newErrors = {};

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -95,7 +95,7 @@ function LoginPage() {
       password: '',
     },
     onSubmit: async () => {
-      const response = await fetch('/login', {
+      const response = await fetch('login', {
         method: 'POST',
         data: {
           email: values.id,


### PR DESCRIPTION
# PR 설명

최소한의 로그인 기능은 지난번에 한번 PR을 작성해서 공유했습니다

1. 로그인 유도 모달창을 추가했습니다
prop으로 true/false 값을 가지는 visible과 해당 state를 false로 바꾸는 handleCloseModal을 넣어주시면 됩니다

2. 로그인 성공 시 cookie에 token을 저장하고, context api에 user 객체를 저장합니다
내가 쓴글, 내가 팔로우한 목록 등을 비교할 때 사용해주세요

현재 로그인시에만 user객체를 저장하고, 새로고침에 대해서는 로직 처리가 되어 있지 않습니다
새로고침 후 context user 데이터를 사용할 경우 cookie를 지우고 다시 로그인해주세요
