### PR TITLE
feat: 로그인 정보를 담는 ContexProvider와 useCookieToken을 수정했다

### DIFF
--- a/src/contexts/ContextProvider.js
+++ b/src/contexts/ContextProvider.js
@@ -1,13 +1,23 @@
-import { createContext, useMemo, useState } from 'react';
+import {
+  createContext,
+  useMemo,
+  useState,
+  useEffect,
+  useCallback,
+} from 'react';
 import PropTypes from 'prop-types';
+import useCookieToken from '@hooks/useCookieToken';
+import { authFetch } from '@utils/fetch';
 
 export const valueContext = createContext();
 export const actionContext = createContext();
 
 function ContextProvider({ children }) {
+  const { token } = useCookieToken();
   const [state, setState] = useState({
     test: 100,
     user: null,
+    isLogin: false,
   });
 
   const actions = useMemo(
@@ -18,12 +28,27 @@ function ContextProvider({ children }) {
       login(user) {
         setState((prevState) => ({
           ...prevState,
+          isLogin: true,
           user,
         }));
       },
     }),
     []
   );
+
+  const getAuthUser = useCallback(async () => {
+    return authFetch('auth-user').then((result) => actions.login(result));
+  }, [actions]);
+
+  useEffect(() => {
+    const { isLogin } = state;
+    if (isLogin) {
+      return;
+    }
+    if (token) {
+      getAuthUser();
+    }
+  }, [state, token, getAuthUser]);
 
   return (
     <actionContext.Provider value={actions}>

--- a/src/hooks/useCookieToken.js
+++ b/src/hooks/useCookieToken.js
@@ -26,7 +26,6 @@ const useCookieToken = () => {
   }, []);
 
   return {
-    isLogin: Boolean(storedCookie),
     token: storedCookie,
     setCookie,
   };

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -11,6 +11,7 @@ import useForm from '@hooks/useForm';
 import { fetch } from '@utils/fetch';
 import useCookieToken from '@hooks/useCookieToken';
 import useActionContext from '@hooks/useActionContext';
+import useValueContext from '@hooks/useValueContext';
 
 const ContentWrapper = styled.div`
   padding: 1.5rem;
@@ -88,15 +89,16 @@ function LoginPage() {
   });
 
   const navigate = useNavigate();
-  const { isLogin, setCookie } = useCookieToken();
+  const { setCookie } = useCookieToken();
   const { login } = useActionContext();
+  const { isLogin } = useValueContext();
   const { values, errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: {
       id: '',
       password: '',
     },
     onSubmit: async () => {
-      const response = await fetch('login', {
+      const { response, token, user } = await fetch('login', {
         method: 'POST',
         data: {
           email: values.id,
@@ -104,9 +106,9 @@ function LoginPage() {
         },
       });
 
-      const isError = Boolean(response?.response);
+      const isError = Boolean(response);
       if (isError) {
-        if (response?.response?.status === 400) {
+        if (response?.status === 400) {
           setWarningAlertInfo({
             visible: true,
             message: '아이디 또는 비밀번호를 잘못 입력했습니다',
@@ -120,8 +122,8 @@ function LoginPage() {
         return;
       }
 
-      setCookie(response.token);
-      login(response.user);
+      setCookie(token);
+      login(user);
     },
     validate: ({ id, password }) => {
       const newErrors = {};


### PR DESCRIPTION
# 주요 PR사항

**로그인 유무를 useCookieToken으로 가져오지 마시고 아래처럼 사용해주세요**

```
const { isLogin, user } = useValueContext();
```

다른분들은 useCookieToken을 사용할 일이 없을 것 같습니다
토큰을 axios에 추가하는건 authFetch에 되어있으니까요

1. useCookieToken은 토큰과 토큰저장함수만을 반환하도록 수정했습니다
2. ContextProvider에서 전역으로 로그인유무, User객체를 사용해주세요 (위 예제 코드 참고 부탁드립니다)

원래 isLogin을 여기서 토큰유무로 반환했습니다
그래서 새로고침 시에는 token이 있어서 로그인된것으로 보았지만, user 객체가 없었습니다

새로고침 시에도 user 객체를 받아오기 위해서 로직을 수정했고
useCookieToken은 `토큰`과 `쿠키저장함수`만을 반환하게 되었습니다

기존에 해당 훅에서 isLogin으로 로그인 유무를 판단해달라고 부탁드렸는데
위 예제 코드와 같이 context api를 통해 사용해주세요

context 내부의 useEffect 로직으로 새로고침시에 알아서 user객체를 가져올겁니다

![새로고침](https://user-images.githubusercontent.com/50919342/173896055-0268980b-810d-4769-b05f-f95b70e2bfa7.png)
콘솔을 찍는다면 새로고침 시 이런식으로 되겠네요
