### PR TITLE
fix: 관심채널 modal을 보여주는 로직을 수정했다

### DIFF
--- a/src/components/InterestedChannelModal/index.js
+++ b/src/components/InterestedChannelModal/index.js
@@ -58,8 +58,15 @@ function InterestedChannelModal() {
   }, [setCookie]);
 
   useEffect(() => {
-    if (openModalInCookie === 'on' && user && !user?.username?.length) {
-      setOpen(true);
+    if (openModalInCookie === 'on' && user) {
+      try {
+        const NoneInterestedChannel = !JSON.parse(user.username)?.length;
+        if (NoneInterestedChannel) {
+          setOpen(true);
+        }
+      } catch (error) {
+        setOpen(true);
+      }
     }
   }, [openModalInCookie, user]);
 


### PR DESCRIPTION
# 주요 PR내용

관심채널 modal을 보여주는 로직을 수정했습니다
user.username을 Json parse해서 관심채널이 있는지 해석하도록 수정했습니다

회원가입만 한 상태라서 user.username 키가 없는 경우와
관심채널을 취소해서 user.username이 빈 배열 문자열인 경우는 관심 채널이 없다는 modal을 보여줍니다

관심채널을 선택해서 user.username이 1개 이상의 배열인 경우는 modal을 보여주지 않습니다
