### PR TITLE
fix: 프로필 페이지에서 유저 정보를 요청하는 getUserInfo를 authFetch에서 fetch로 수정했다

### DIFF
--- a/src/utils/user/index.js
+++ b/src/utils/user/index.js
@@ -26,7 +26,7 @@ export const changeMyInfoAPI = (option) => {
 };
 
 export const getUserInfo = (userId) => {
-  return authFetch(endpoints.getUserInfo(userId));
+  return fetch(endpoints.getUserInfo(userId));
 };
 
 export const getAllUserList = () => {


### PR DESCRIPTION
# 주요 PR 내용

profile에서 유저 정보를 요청하는 API를 authFetch로 사용하고 있어서
비로그인 시 에러가 발생합니다

해당 요청은 token을 사용하지 않기 때문에 authFetch가 아니라 fetch로 수정하였습니다