### PR TITLE
fix: 새로고침 시 자동 로그인 완료 snackbar 닫기 오류를 수정했다

### DIFF
--- a/src/hooks/useOurSnackbar.js
+++ b/src/hooks/useOurSnackbar.js
@@ -10,7 +10,11 @@ const WhiteColorButton = styled(Button)`
 
 const useOurSnackbar = () => {
   const { enqueueSnackbar } = useSnackbar();
-  const { ref } = useValueContext();
+  const value = useValueContext();
+
+  const handleClickSnackbar = (key) => {
+    value.ref.current.closeSnackbar(key);
+  };
 
   const renderSnackbar = (message, isSuccess = null) => {
     if (isSuccess === null) {
@@ -21,7 +25,7 @@ const useOurSnackbar = () => {
           horizontal: 'center',
         },
         action: (key) => (
-          <WhiteColorButton onClick={() => ref.current.closeSnackbar(key)}>
+          <WhiteColorButton onClick={() => handleClickSnackbar(key)}>
             닫기
           </WhiteColorButton>
         ),
@@ -37,7 +41,7 @@ const useOurSnackbar = () => {
           horizontal: 'center',
         },
         action: (key) => (
-          <WhiteColorButton onClick={() => ref.current.closeSnackbar(key)}>
+          <WhiteColorButton onClick={() => handleClickSnackbar(key)}>
             닫기
           </WhiteColorButton>
         ),


### PR DESCRIPTION
# 주요 PR 내용

새로고침 시 **자동 로그인 완료 snackbar**에서 **닫기**를 눌렀을 때 오류가 발생하는것을 민제님이 제보해주셔서 수정했습니다

2번 렌더링을 방지하려고 ref를 context 객체의 주소값을 변경하지 않도록 수정했는데, 이때 생긴 문제입니다
ref만을 가져오지 않고 전체 value를 가져오도록 수정했습니다

