### PR TITLE
fix: 알림 api의 오류를 수정했다.

### DIFF
--- a/src/pages/PostDetailPage.js
+++ b/src/pages/PostDetailPage.js
@@ -144,7 +144,7 @@ function PostDetailPage() {
       data: {
         notificationType: type,
         notificationTypeId: infoObject._id,
-        userId: user._id,
+        userId: detailData.author._id,
         postId: infoObject.post,
       },
     });


### PR DESCRIPTION
알림을 보내는 대상이 글 작성자가 아닌 좋아요, 댓글을 보내는 사람이었던 오류를 수정했다.
