### PR TITLE
fix: assets이미지 export의 id 값을 수정했고, 홈 페이지 title 파싱 방법을 dt로 통일했다.

### DIFF
--- a/src/assets/ChannelIcons/index.js
+++ b/src/assets/ChannelIcons/index.js
@@ -5,11 +5,11 @@ import overwatch from './Icon_오버워치.png';
 import battleground from './Icon_배틀그라운드.png';
 
 const IconImages = {
-  '62a7367f5517e27ffcab3bcb': maple,
-  '62a736925517e27ffcab3bcf': lol,
-  '62a818db5517e27ffcab3ce2': lostark,
-  '62a818e85517e27ffcab3ce6': overwatch,
-  '62a736a15517e27ffcab3bd5': battleground,
+  '62b2c99563a66405b814409e': maple,
+  '62b2c98063a66405b8144096': lol,
+  '62b2c9a363a66405b81440a2': battleground,
+  '62b2c9a963a66405b81440a6': lostark,
+  '62b2c9ae63a66405b81440aa': overwatch,
 };
 
 export default IconImages;

--- a/src/assets/ChannelImages/index.js
+++ b/src/assets/ChannelImages/index.js
@@ -7,11 +7,11 @@ import battleground from './ChannelBanner_PUBG.png';
 export { maple, lol, lostark, overwatch, battleground };
 
 const bannerImages = {
-  '62a7367f5517e27ffcab3bcb': maple,
-  '62a736925517e27ffcab3bcf': lol,
-  '62a818db5517e27ffcab3ce2': lostark,
-  '62a818e85517e27ffcab3ce6': overwatch,
-  '62a736a15517e27ffcab3bd5': battleground,
+  '62b2c99563a66405b814409e': maple,
+  '62b2c98063a66405b8144096': lol,
+  '62b2c9a363a66405b81440a2': battleground,
+  '62b2c9a963a66405b81440a6': lostark,
+  '62b2c9ae63a66405b81440aa': overwatch,
 };
 
 export default bannerImages;

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -139,11 +139,8 @@ function HomePage() {
         <Divider />
         {posts &&
           posts.map((item) => {
-            let { title } = item;
-            if (title.startsWith('{')) {
-              title = JSON.parse(title).tt || JSON.parse(title).dt;
-              // TODO : 추후 게시글 정리 후 dt로 통일
-            }
+            const titleJSON = JSON.parse(item.title);
+            const title = titleJSON.dt;
             const categoriesId = item.channel?._id;
             const comments = item.comments.length;
 


### PR DESCRIPTION
## 👩‍💻 구현 내용
1. assets ChannelIcons와 ChannelImages export 채널 id 값을 수정했다.
2. 홈 페이지 title 파싱 방법을 dt, tt 혼용에서 dt로 통일했다.