### PR TITLE
feat: 로그인 / 회원가입 / 이름 변경 시 길이 검사를 추가했다

### DIFF
--- a/src/components/EditFullNameModal/index.js
+++ b/src/components/EditFullNameModal/index.js
@@ -9,7 +9,7 @@ import useValueContext from '@hooks/useValueContext';
 import useActionContext from '@hooks/useActionContext';
 import { COLOR_MAIN } from '@utils/color';
 import { changeMyInfoAPI } from '@utils/user';
-import { regexName } from '@utils/constants';
+import { regexName, MAX_NAME_LENGTH } from '@utils/constants';
 
 const ModalContentWrapper = styled(Box)`
   position: absolute;
@@ -81,6 +81,8 @@ function EditFullNameModal({ visible, handleCloseModal, onSuccess, onError }) {
       const filteredName = fullName.replace(regexName, '');
       if (fullName !== filteredName)
         newErrors.fullName = '사용할 수 없는 문자가 포함되어 있습니다';
+      if (fullName.length > MAX_NAME_LENGTH)
+        newErrors.fullName = '변경할 이름이 너무 깁니다';
       return newErrors;
     },
   });

--- a/src/pages/DetailMessage.js
+++ b/src/pages/DetailMessage.js
@@ -109,6 +109,10 @@ const Title = styled.h1`
   flex-grow: 1;
 `;
 
+const FitDiv = styled.div`
+  width: fit-content;
+`;
+
 const Time = styled.div`
   text-align: ${({ isMe }) => (isMe ? 'end' : 'start')};
   font-size: 0.75rem;
@@ -172,7 +176,9 @@ function DetailMessage() {
         return (
           <span key={_id}>
             <Time isMe={isMe}>{createdAt.slice(0, 16).replace('T', ' ')}</Time>
-            <div className={`msg ${isMe ? 'sent' : 'rcvd'}`}>{message}</div>
+            <FitDiv className={`msg ${isMe ? 'sent' : 'rcvd'}`}>
+              {message}
+            </FitDiv>
           </span>
         );
       })

--- a/src/pages/LoginPage.js
+++ b/src/pages/LoginPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import styled from '@emotion/styled';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
@@ -10,7 +10,13 @@ import useCookieToken from '@hooks/useCookieToken';
 import useActionContext from '@hooks/useActionContext';
 import useValueContext from '@hooks/useValueContext';
 import GoBack from '@components/GoBack';
-import { GAMEBU_TOKEN, regexId } from '@utils/constants';
+import {
+  GAMEBU_TOKEN,
+  regexId,
+  MAX_ID_LENGTH,
+  MAX_PASSWORD_LENGTH,
+  MIN_LENGTH,
+} from '@utils/constants';
 import { loginAPI } from '@utils/user';
 import useOurSnackbar from '@hooks/useOurSnackbar';
 
@@ -93,6 +99,8 @@ const SignupLink = styled(Link)`
 `;
 
 function LoginPage() {
+  const idRef = useRef();
+  const passwordRef = useRef();
   const navigate = useNavigate();
   const [, setToken] = useCookieToken(GAMEBU_TOKEN);
   const { login } = useActionContext();
@@ -128,14 +136,27 @@ function LoginPage() {
     },
     validate: ({ id, password }) => {
       const newErrors = {};
+      if (id.length < MIN_LENGTH) newErrors.id = '아이디가 너무 짧습니다';
       if (!id) newErrors.id = '아이디를 입력하세요';
       const filteredId = id.replace(regexId, '');
       if (id !== filteredId)
         newErrors.id = '사용할 수 없는 문자가 포함되어 있습니다';
+
+      if (password.length < MIN_LENGTH)
+        newErrors.password = '비밀번호가 너무 짧습니다';
       if (!password) newErrors.password = '비밀번호를 입력하세요';
       return newErrors;
     },
   });
+
+  useEffect(() => {
+    idRef.current
+      .querySelector('[name=id]')
+      .setAttribute('maxlength', MAX_ID_LENGTH);
+    passwordRef.current
+      .querySelector('[name=password]')
+      .setAttribute('maxlength', MAX_PASSWORD_LENGTH);
+  }, []);
 
   useEffect(() => {
     if (isLogin) {
@@ -151,6 +172,7 @@ function LoginPage() {
       <FormWrapper>
         <Form onSubmit={handleSubmit}>
           <StyledTextField
+            ref={idRef}
             label="아이디"
             values={values.id}
             onChange={handleChange}
@@ -160,6 +182,7 @@ function LoginPage() {
             error={Boolean(errors.id)}
           />
           <StyledTextField
+            ref={passwordRef}
             label="비밀번호"
             value={values.password}
             onChange={handleChange}

--- a/src/pages/SignupPage.js
+++ b/src/pages/SignupPage.js
@@ -1,11 +1,18 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import styled from '@emotion/styled';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import { COLOR_BG, COLOR_MAIN, COLOR_SIGNATURE } from '@utils/color';
 import useForm from '@hooks/useForm';
 import GoBack from '@components/GoBack';
-import { regexId, regexName } from '@utils/constants';
+import {
+  regexId,
+  regexName,
+  MAX_ID_LENGTH,
+  MAX_NAME_LENGTH,
+  MAX_PASSWORD_LENGTH,
+  MIN_LENGTH,
+} from '@utils/constants';
 import { useNavigate } from 'react-router-dom';
 import { signupAPI } from '@utils/user';
 import useOurSnackbar from '@hooks/useOurSnackbar';
@@ -79,6 +86,10 @@ const SignupButton = styled(Button)`
 `;
 
 function SignupPage() {
+  const idRef = useRef();
+  const nameRef = useRef();
+  const passwordRef = useRef();
+  const passwordConfirmRef = useRef();
   const renderSnackbar = useOurSnackbar();
   const navigate = useNavigate();
   const { values, errors, isLoading, handleChange, handleSubmit } = useForm({
@@ -112,14 +123,19 @@ function SignupPage() {
     },
     validate: ({ id, name, password, passwordConfirm }) => {
       const newErrors = {};
+      if (id.length < MIN_LENGTH) newErrors.id = '아이디가 너무 짧습니다';
       if (!id) newErrors.id = '아이디를 입력하세요';
       const filteredId = id.replace(regexId, '');
       if (id !== filteredId)
         newErrors.id = '아이디에 사용할 수 없는 문자가 포함되어 있습니다';
+
       if (!name) newErrors.name = '이름을 입력하세요';
       const filteredName = name.replace(regexName, '');
       if (name !== filteredName)
         newErrors.name = '이름에 사용할 수 없는 문자가 포함되어 있습니다';
+
+      if (password.length < MIN_LENGTH)
+        newErrors.password = '비밀번호가 너무 짧습니다';
       if (!password) newErrors.password = '비밀번호를 입력하세요';
       if (!passwordConfirm)
         newErrors.passwordConfirm = '비밀번호 확인을 입력하세요';
@@ -130,6 +146,21 @@ function SignupPage() {
     },
   });
 
+  useEffect(() => {
+    idRef.current
+      .querySelector('[name=id]')
+      .setAttribute('maxlength', MAX_ID_LENGTH);
+    nameRef.current
+      .querySelector('[name=name]')
+      .setAttribute('maxlength', MAX_NAME_LENGTH);
+    passwordRef.current
+      .querySelector('[name=password]')
+      .setAttribute('maxlength', MAX_PASSWORD_LENGTH);
+    passwordConfirmRef.current
+      .querySelector('[name=passwordConfirm]')
+      .setAttribute('maxlength', MAX_PASSWORD_LENGTH);
+  }, []);
+
   return (
     <ContentWrapper>
       <GoBack />
@@ -138,6 +169,7 @@ function SignupPage() {
       <FormWrapper>
         <Form onSubmit={handleSubmit}>
           <StyledTextField
+            ref={idRef}
             label="아이디"
             values={values.id}
             onChange={handleChange}
@@ -147,6 +179,7 @@ function SignupPage() {
             error={Boolean(errors.id)}
           />
           <StyledTextField
+            ref={nameRef}
             label="이름"
             values={values.name}
             onChange={handleChange}
@@ -156,6 +189,7 @@ function SignupPage() {
             error={Boolean(errors.name)}
           />
           <StyledTextField
+            ref={passwordRef}
             label="비밀번호"
             value={values.password}
             onChange={handleChange}
@@ -167,6 +201,7 @@ function SignupPage() {
             error={Boolean(errors.password)}
           />
           <StyledTextField
+            ref={passwordConfirmRef}
             label="비밀번호 확인"
             value={values.passwordConfirm}
             onChange={handleChange}

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -48,3 +48,8 @@ export const CHANNEL_MODAL_VISIBLE = 'CHANNEL_MODAL_VISIBLE';
 
 export const regexId = /[^0-9a-zA-Z]/g;
 export const regexName = /[^0-9a-zA-Zㄱ-ㅎ가-힣]/g;
+
+export const MAX_NAME_LENGTH = 10;
+export const MAX_ID_LENGTH = 20;
+export const MAX_PASSWORD_LENGTH = 20;
+export const MIN_LENGTH = 4;


### PR DESCRIPTION
# 주요 PR 내용

로그인 / 회원가입 페이지 폼과
프로필 페이지에서 이름 변경할 때

아이디, 이름, 비밀번호에 길이 검사를 추가했습니다

프로필 페이지의 modal은 ref가 동작하지 않아서 하지 않았습니다