### PR TITLE
fix: 비로그인 시 UserSidebar에서 user._id를 찾지 못하는 현상을 수정했다

### DIFF
--- a/src/components/Topbar/UserSidebar.js
+++ b/src/components/Topbar/UserSidebar.js
@@ -54,7 +54,9 @@ function UserSidebar({ open, onClose }) {
       <Divider />
       <List>
         {userList
-          .filter((item) => item._id !== user._id && item.role !== 'SuperAdmin')
+          .filter(
+            (item) => item._id !== user?._id && item.role !== 'SuperAdmin'
+          )
           .sort((a, b) => b.isOnline - a.isOnline)
           .map(({ _id, fullName, isOnline }) => {
             return (


### PR DESCRIPTION
# 주요 PR 내용

UserSidebar는 자신과 admin이 아닌유저로 필터링합니다
이때 비로그인이면 null._id를 찾으려고 하는 오류가 있어서 수정했습니다